### PR TITLE
Implement shift timer

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { SidebarHeader } from "@/components/dashboard/sidebar/sidebar-header";
+import { ShiftTimer } from "@/components/dashboard/shift-timer";
 import Link from "next/link";
 
 export default function Page() {
@@ -6,9 +7,7 @@ export default function Page() {
     <>
       <SidebarHeader section="Panel de gestión" title="Inicio" />
       <main className=" grid grid-cols-12 gap-4 p-4 place-items-center h-full">
-        <div className="hover:animate-pulse hover:text-xl border h-full w-full col-span-12 sm:col-span-4 grid place-items-center rounded">
-          Inciar turno
-        </div>
+        <ShiftTimer />
         <Link
           href="/articles"
           className="hover:animate-pulse hover:text-xl border h-full w-full col-span-12 sm:col-span-4 grid place-items-center rounded"

--- a/src/components/dashboard/shift-timer.tsx
+++ b/src/components/dashboard/shift-timer.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useShiftTimer, formatElapsed } from "@/hooks/use-shift-timer";
+
+export function ShiftTimer() {
+  const { isRunning, elapsed, startTimer, stopTimer } = useShiftTimer();
+
+  const handleClick = () => {
+    if (isRunning) {
+      stopTimer();
+    } else {
+      startTimer();
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="hover:animate-pulse hover:text-xl border h-full w-full col-span-12 sm:col-span-4 grid place-items-center rounded"
+    >
+      {isRunning ? `Terminar turno (${formatElapsed(elapsed)})` : "Iniciar turno"}
+    </button>
+  );
+}

--- a/src/hooks/use-shift-timer.ts
+++ b/src/hooks/use-shift-timer.ts
@@ -1,0 +1,60 @@
+import * as React from "react";
+
+const STORAGE_KEY = "shift_start";
+
+export function useShiftTimer() {
+  const [start, setStart] = React.useState<number | null>(null);
+  const [elapsed, setElapsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+    if (stored) {
+      const value = parseInt(stored, 10);
+      if (!isNaN(value)) {
+        setStart(value);
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    let interval: number | undefined;
+    if (start !== null) {
+      const update = () => setElapsed(Date.now() - start);
+      update();
+      interval = window.setInterval(update, 1000);
+    }
+    return () => {
+      if (interval) window.clearInterval(interval);
+    };
+  }, [start]);
+
+  const startTimer = React.useCallback(() => {
+    const now = Date.now();
+    localStorage.setItem(STORAGE_KEY, String(now));
+    setStart(now);
+  }, []);
+
+  const stopTimer = React.useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setStart(null);
+    setElapsed(0);
+  }, []);
+
+  return {
+    start,
+    elapsed,
+    isRunning: start !== null,
+    startTimer,
+    stopTimer,
+  };
+}
+
+export function formatElapsed(ms: number) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return [hours, minutes, seconds]
+    .map((n) => String(n).padStart(2, "0"))
+    .join(":");
+}


### PR DESCRIPTION
## Summary
- add `useShiftTimer` hook for starting and stopping a timer persisted in `localStorage`
- create `ShiftTimer` component with start/stop button and elapsed time display
- wire shift timer into dashboard

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844917b3990832aa34386f0b980d252