### PR TITLE
Implement articles and ingredients management

### DIFF
--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { useParams } from "next/navigation";
+import { SidebarHeader } from "@/components/dashboard/sidebar/sidebar-header";
+import { ArticleForm } from "@/components/articles/article-form";
+import { useArticles } from "@/hooks/use-articles";
+
+export default function EditArticlePage() {
+  const { id } = useParams<{ id: string }>();
+  const { articles, updateArticle } = useArticles();
+  const article = articles.find((a) => a.id === Number(id));
+
+  if (!article) {
+    return <p className="p-4">Artículo no encontrado</p>;
+  }
+
+  return (
+    <>
+      <SidebarHeader section="Articulos" title="Editar pizza" />
+      <main className="p-4 max-w-lg mx-auto">
+        <ArticleForm onSubmit={(data) => updateArticle(article.id, data)} initialData={article} />
+      </main>
+    </>
+  );
+}

--- a/src/app/articles/layout.tsx
+++ b/src/app/articles/layout.tsx
@@ -1,0 +1,15 @@
+import { AppSidebar } from "@/components/dashboard/sidebar/app-sidebar";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+
+export default function ArticlesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>{children}</SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/src/app/articles/new/page.tsx
+++ b/src/app/articles/new/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { SidebarHeader } from "@/components/dashboard/sidebar/sidebar-header";
+import { ArticleForm } from "@/components/articles/article-form";
+import { useArticles } from "@/hooks/use-articles";
+
+export default function NewArticlePage() {
+  const { addArticle } = useArticles();
+
+  return (
+    <>
+      <SidebarHeader section="Articulos" title="Crear pizza" />
+      <main className="p-4 max-w-lg mx-auto">
+        <ArticleForm onSubmit={addArticle} />
+      </main>
+    </>
+  );
+}

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,0 +1,13 @@
+import { SidebarHeader } from "@/components/dashboard/sidebar/sidebar-header";
+import { ArticleTable } from "@/components/articles/article-table";
+
+export default function ArticlesPage() {
+  return (
+    <>
+      <SidebarHeader section="Articulos" title="Pizzas" />
+      <main className="p-4">
+        <ArticleTable />
+      </main>
+    </>
+  );
+}

--- a/src/app/ingredients/[id]/edit/page.tsx
+++ b/src/app/ingredients/[id]/edit/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { useParams } from "next/navigation";
+import { SidebarHeader } from "@/components/dashboard/sidebar/sidebar-header";
+import { IngredientForm } from "@/components/ingredients/ingredient-form";
+import { useIngredients } from "@/hooks/use-ingredients";
+
+export default function EditIngredientPage() {
+  const { id } = useParams<{ id: string }>();
+  const { ingredients, updateIngredient } = useIngredients();
+  const ingredient = ingredients.find((i) => i.id === Number(id));
+
+  if (!ingredient) {
+    return <p className="p-4">Ingrediente no encontrado</p>;
+  }
+
+  return (
+    <>
+      <SidebarHeader section="Articulos" title="Editar ingrediente" />
+      <main className="p-4 max-w-lg mx-auto">
+        <IngredientForm onSubmit={(data) => updateIngredient(ingredient.id, data)} initialData={ingredient} />
+      </main>
+    </>
+  );
+}

--- a/src/app/ingredients/layout.tsx
+++ b/src/app/ingredients/layout.tsx
@@ -1,0 +1,15 @@
+import { AppSidebar } from "@/components/dashboard/sidebar/app-sidebar";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+
+export default function IngredientsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>{children}</SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/src/app/ingredients/new/page.tsx
+++ b/src/app/ingredients/new/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { SidebarHeader } from "@/components/dashboard/sidebar/sidebar-header";
+import { IngredientForm } from "@/components/ingredients/ingredient-form";
+import { useIngredients } from "@/hooks/use-ingredients";
+
+export default function NewIngredientPage() {
+  const { addIngredient } = useIngredients();
+  return (
+    <>
+      <SidebarHeader section="Articulos" title="Crear ingrediente" />
+      <main className="p-4 max-w-lg mx-auto">
+        <IngredientForm onSubmit={addIngredient} />
+      </main>
+    </>
+  );
+}

--- a/src/app/ingredients/page.tsx
+++ b/src/app/ingredients/page.tsx
@@ -1,0 +1,13 @@
+import { SidebarHeader } from "@/components/dashboard/sidebar/sidebar-header";
+import { IngredientTable } from "@/components/ingredients/ingredient-table";
+
+export default function IngredientsPage() {
+  return (
+    <>
+      <SidebarHeader section="Articulos" title="Ingredientes" />
+      <main className="p-4">
+        <IngredientTable />
+      </main>
+    </>
+  );
+}

--- a/src/components/articles/article-form.tsx
+++ b/src/components/articles/article-form.tsx
@@ -1,0 +1,101 @@
+'use client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useIngredients } from '@/hooks/use-ingredients';
+import { Article } from '@/hooks/use-articles';
+
+const schema = z.object({
+  name: z.string().min(1, 'Nombre requerido'),
+  price: z.coerce.number().nonnegative({ message: 'Precio inválido' }),
+  ingredients: z.array(z.number()).optional().default([]),
+});
+
+export function ArticleForm({
+  initialData,
+  onSubmit,
+}: {
+  initialData?: Article;
+  onSubmit: (data: Omit<Article, 'id'>) => void;
+}) {
+  const { ingredients } = useIngredients();
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+    defaultValues: initialData ?? { name: '', price: 0, ingredients: [] },
+  });
+
+  const handleSubmit = (values: z.infer<typeof schema>) => {
+    onSubmit(values);
+    form.reset();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nombre</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="price"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Precio</FormLabel>
+              <FormControl>
+                <Input type="number" step="0.01" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div>
+          <FormLabel>Ingredientes</FormLabel>
+          <div className="grid grid-cols-2 gap-2 mt-2">
+            {ingredients.map((ing) => (
+              <FormField
+                key={ing.id}
+                control={form.control}
+                name="ingredients"
+                render={({ field }) => (
+                  <FormItem className="flex items-center gap-2">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value?.includes(ing.id)}
+                        onCheckedChange={(checked) => {
+                          const ids = field.value || [];
+                          if (checked) {
+                            field.onChange([...ids, ing.id]);
+                          } else {
+                            field.onChange(ids.filter((id) => id !== ing.id));
+                          }
+                        }}
+                      />
+                    </FormControl>
+                    <FormLabel className="!mb-0 cursor-pointer" htmlFor={undefined}>{ing.name}</FormLabel>
+                  </FormItem>
+                )}
+              />
+            ))}
+          </div>
+        </div>
+        <Button type="submit" className="w-full">
+          Guardar
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/articles/article-table.tsx
+++ b/src/components/articles/article-table.tsx
@@ -1,0 +1,50 @@
+'use client';
+import Link from 'next/link';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { useArticles } from '@/hooks/use-articles';
+import { useIngredients } from '@/hooks/use-ingredients';
+
+export function ArticleTable() {
+  const { articles, deleteArticle } = useArticles();
+  const { ingredients } = useIngredients();
+
+  const ingredientName = (id: number) => ingredients.find(i => i.id === id)?.name || '';
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button asChild>
+          <Link href="/articles/new">Crear pizza</Link>
+        </Button>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Nombre</TableHead>
+            <TableHead>Precio</TableHead>
+            <TableHead>Ingredientes</TableHead>
+            <TableHead className="w-28" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {articles.map((article) => (
+            <TableRow key={article.id}>
+              <TableCell>{article.name}</TableCell>
+              <TableCell>${article.price.toFixed(2)}</TableCell>
+              <TableCell>{article.ingredients.map(ingredientName).join(', ')}</TableCell>
+              <TableCell className="flex gap-2">
+                <Button size="sm" asChild variant="outline">
+                  <Link href={`/articles/${article.id}/edit`}>Editar</Link>
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => deleteArticle(article.id)}>
+                  Eliminar
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/dashboard/sidebar/app-sidebar.tsx
+++ b/src/components/dashboard/sidebar/app-sidebar.tsx
@@ -38,20 +38,20 @@ const data = {
   navMain: [
     {
       title: "Administrar",
-      url: "#",
+      url: "/articles",
       icon: SquareTerminal,
       isActive: false,
 
     },
     {
       title: "Crear pizza",
-      url: "#",
+      url: "/articles/new",
       icon: Bot,
 
     },
     {
-      title: "Administrar ingredientes",
-      url: "#",
+      title: "Ingredientes",
+      url: "/ingredients",
       icon: BookOpen,
 
     },

--- a/src/components/ingredients/ingredient-form.tsx
+++ b/src/components/ingredients/ingredient-form.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Ingredient } from '@/hooks/use-ingredients';
+
+const schema = z.object({
+  name: z.string().min(1, 'Nombre requerido'),
+});
+
+export function IngredientForm({
+  initialData,
+  onSubmit,
+}: {
+  initialData?: Ingredient;
+  onSubmit: (data: Omit<Ingredient, 'id'>) => void;
+}) {
+  const form = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+    defaultValues: initialData ?? { name: '' },
+  });
+
+  const handleSubmit = (values: z.infer<typeof schema>) => {
+    onSubmit(values);
+    form.reset();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nombre</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full">
+          Guardar
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/ingredients/ingredient-table.tsx
+++ b/src/components/ingredients/ingredient-table.tsx
@@ -1,0 +1,42 @@
+'use client';
+import Link from 'next/link';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { useIngredients } from '@/hooks/use-ingredients';
+
+export function IngredientTable() {
+  const { ingredients, deleteIngredient } = useIngredients();
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button asChild>
+          <Link href="/ingredients/new">Crear ingrediente</Link>
+        </Button>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Nombre</TableHead>
+            <TableHead className="w-28" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {ingredients.map((ing) => (
+            <TableRow key={ing.id}>
+              <TableCell>{ing.name}</TableCell>
+              <TableCell className="flex gap-2">
+                <Button size="sm" asChild variant="outline">
+                  <Link href={`/ingredients/${ing.id}/edit`}>Editar</Link>
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => deleteIngredient(ing.id)}>
+                  Eliminar
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/hooks/use-articles.ts
+++ b/src/hooks/use-articles.ts
@@ -1,0 +1,26 @@
+import { useLocalStorage } from './use-local-storage';
+
+export interface Article {
+  id: number;
+  name: string;
+  price: number;
+  ingredients: number[];
+}
+
+export function useArticles() {
+  const [articles, setArticles] = useLocalStorage<Article[]>('articles', []);
+
+  const addArticle = (data: Omit<Article, 'id'>) => {
+    setArticles([...articles, { ...data, id: Date.now() }]);
+  };
+
+  const updateArticle = (id: number, data: Omit<Article, 'id'>) => {
+    setArticles(articles.map((a) => (a.id === id ? { ...a, ...data, id } : a)));
+  };
+
+  const deleteArticle = (id: number) => {
+    setArticles(articles.filter((a) => a.id !== id));
+  };
+
+  return { articles, addArticle, updateArticle, deleteArticle };
+}

--- a/src/hooks/use-ingredients.ts
+++ b/src/hooks/use-ingredients.ts
@@ -1,0 +1,24 @@
+import { useLocalStorage } from './use-local-storage';
+
+export interface Ingredient {
+  id: number;
+  name: string;
+}
+
+export function useIngredients() {
+  const [ingredients, setIngredients] = useLocalStorage<Ingredient[]>('ingredients', []);
+
+  const addIngredient = (data: Omit<Ingredient, 'id'>) => {
+    setIngredients([...ingredients, { ...data, id: Date.now() }]);
+  };
+
+  const updateIngredient = (id: number, data: Omit<Ingredient, 'id'>) => {
+    setIngredients(ingredients.map((i) => (i.id === id ? { ...i, ...data, id } : i)));
+  };
+
+  const deleteIngredient = (id: number) => {
+    setIngredients(ingredients.filter((i) => i.id !== id));
+  };
+
+  return { ingredients, addIngredient, updateIngredient, deleteIngredient };
+}

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = React.useState<T>(() => {
+    if (typeof window === 'undefined') return initialValue;
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const setStoredValue = React.useCallback(
+    (val: T | ((prev: T) => T)) => {
+      setValue((prev) => {
+        const valueToStore = val instanceof Function ? val(prev) : val;
+        try {
+          if (typeof window !== 'undefined') {
+            window.localStorage.setItem(key, JSON.stringify(valueToStore));
+          }
+        } catch {}
+        return valueToStore;
+      });
+    },
+    [key]
+  );
+
+  return [value, setStoredValue] as const;
+}


### PR DESCRIPTION
## Summary
- add CRUD pages for articles and ingredients
- implement tables and forms using shadcn components
- store data in localStorage with hooks
- update sidebar navigation

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449609aff4832aa586a88be981fa51